### PR TITLE
Fix method call causing key error 

### DIFF
--- a/cpg_flow_test/stages.py
+++ b/cpg_flow_test/stages.py
@@ -142,7 +142,7 @@ class BuildAPrimePyramid(MultiCohortStage):
         }
 
     def queue_jobs(self, multicohort: MultiCohort, inputs: StageInput) -> StageOutput | None:
-        input_files_filter_evens = inputs.as_dict(multicohort, FilterEvens)
+        input_files_filter_evens = inputs.as_dict_by_target(FilterEvens)
         print('----INPUT FILES FILTER EVENS----')
         print(input_files_filter_evens)
 

--- a/cpg_flow_test/stages.py
+++ b/cpg_flow_test/stages.py
@@ -154,7 +154,7 @@ class BuildAPrimePyramid(MultiCohortStage):
         for cohort in multicohort.get_cohorts():
             for sg in cohort.get_sequencing_groups():
                 input_files[sg.id] = {}
-                input_files[sg.id]['no_evens'] = input_files_filter_evens[sg.id]
+                input_files[sg.id]['no_evens'] = input_files_filter_evens[cohort.id][sg.id]
                 input_files[sg.id]['id_sum'] = input_files_generate_primes[sg.id]['id_sum']
                 input_files[sg.id]['primes'] = input_files_generate_primes[sg.id]['primes']
 


### PR DESCRIPTION
This stage was resulting in the following error 

```
Traceback (most recent call last):
  File "/cpg-flow/test_workflows_shared/cpg_flow_test/./workflow.py", line 40, in <module>
    run_cpg_flow()
  File "/cpg-flow/test_workflows_shared/cpg_flow_test/./workflow.py", line 23, in run_cpg_flow
    run_workflow(stages=workflow, dry_run=dry_run)
  File "/cpg-flow/src/cpg_flow/workflow.py", line 160, in run_workflow
    wfl.run(stages=stages, wait=wait)
  File "/cpg-flow/src/cpg_flow/workflow.py", line 268, in run
    self.set_stages(_stages)
  File "/cpg-flow/src/cpg_flow/workflow.py", line 519, in set_stages
    stg.output_by_target = stg.queue_for_multicohort(inputs)
  File "/cpg-flow/src/cpg_flow/stage.py", line 935, in queue_for_multicohort
    output_by_target[multicohort.target_id] = self._queue_jobs_with_checks(
  File "/cpg-flow/src/cpg_flow/stage.py", line 500, in _queue_jobs_with_checks
    outputs = self.queue_jobs(target, inputs)
  File "/cpg-flow/test_workflows_shared/cpg_flow_test/stages.py", line 145, in queue_jobs
    input_files_filter_evens = inputs.as_dict(multicohort, FilterEvens)
  File "/cpg-flow/src/cpg_flow/stage.py", line 279, in as_dict
    res = self._get(target=target, stage=stage)
  File "/cpg-flow/src/cpg_flow/stage.py", line 244, in _get
    raise StageInputNotFoundError(
cpg_flow.stage.StageInputNotFoundError: Not found output for MultiCohort(1 cohorts) from stage FilterEvens, required for stage BuildAPrimePyramid
```


When you inspect the returned dictionary, it was trying to key according to the multicohort name, however given the previous target was a cohort, the outputs were keyed via the cohort id. This was not caught for single cohort runs, as the cohort ID and multicohort ID were the same. 

This was identified following this change in cpg_flow https://github.com/populationgenomics/cpg-flow/pull/51 as the multicohort name was changed to be a hash, and this problem was uncovered. 
