### PR TITLE
SET-339 use loguru in test repo

### DIFF
--- a/cpg_flow_test/jobs/build_pyramid.py
+++ b/cpg_flow_test/jobs/build_pyramid.py
@@ -3,6 +3,7 @@ from typing import Any
 from cpg_flow.targets.sequencing_group import SequencingGroup
 from hailtop.batch import Batch
 from hailtop.batch.job import Job
+from loguru import logger
 
 
 def build_pyramid(
@@ -55,8 +56,8 @@ def build_pyramid(
     job.command(f'cat {inputs} >> {job.pyramid}')
     b.write_output(job.pyramid, output_file_path)
 
-    print('-----PRINT PYRAMID-----')
-    print(output_file_path)
+    logger.info('-----PRINT PYRAMID-----')
+    logger.info(output_file_path)
 
     all_jobs = [job, *sg_jobs]
 

--- a/cpg_flow_test/jobs/cumulative_calc.py
+++ b/cpg_flow_test/jobs/cumulative_calc.py
@@ -1,6 +1,7 @@
 from cpg_flow.targets.sequencing_group import SequencingGroup
 from hailtop.batch import Batch
 from hailtop.batch.job import Job
+from loguru import logger
 
 
 def cumulative_calc(
@@ -26,8 +27,8 @@ def cumulative_calc(
 
     job.command(cmd)
 
-    print('-----PRINT CUMULATIVE-----')
-    print(output_file_path)
+    logger.info('-----PRINT CUMULATIVE-----')
+    logger.info(output_file_path)
     b.write_output(job.cumulative, output_file_path)
 
     return job

--- a/cpg_flow_test/jobs/filter_evens.py
+++ b/cpg_flow_test/jobs/filter_evens.py
@@ -4,12 +4,11 @@ from cpg_flow.stage import Stage, StageInput
 from cpg_flow.targets.sequencing_group import SequencingGroup
 from hailtop.batch import Batch
 from hailtop.batch.job import Job
+from loguru import logger
 
 
 def filter_evens(
     b: Batch,
-    inputs: StageInput,
-    previous_stage: Stage,
     sequencing_groups: list[SequencingGroup],
     input_files: dict[str, dict[str, Any]],
     sg_outputs: dict[str, dict[str, Any]],
@@ -23,7 +22,6 @@ def filter_evens(
     for sg in sequencing_groups:  # type: ignore
         job = b.new_job(name=title + ': ' + sg.id)
         input_file_path = input_files[sg.id]['cumulative']
-        input_file_path = inputs.as_path(sg, previous_stage, 'cumulative')
         no_evens_input_file = b.read_input(input_file_path)
         no_evens_output_file_path = str(sg_outputs[sg.id])
         sg_output_files.append(no_evens_output_file_path)
@@ -50,8 +48,8 @@ def filter_evens(
     job.command(f'cat {inputs} >> {job.no_evens_file}')
     b.write_output(job.no_evens_file, output_file_path)
 
-    print('-----PRINT NO EVENS-----')
-    print(output_file_path)
+    logger.info('-----PRINT NO EVENS-----')
+    logger.info(output_file_path)
 
     all_jobs = [job, *sg_jobs]
 

--- a/cpg_flow_test/jobs/first_n_primes.py
+++ b/cpg_flow_test/jobs/first_n_primes.py
@@ -1,8 +1,7 @@
-from loguru import logger
-
 from cpg_flow.targets.sequencing_group import SequencingGroup
 from hailtop.batch import Batch
 from hailtop.batch.job import Job
+from loguru import logger
 
 
 def first_n_primes(

--- a/cpg_flow_test/jobs/first_n_primes.py
+++ b/cpg_flow_test/jobs/first_n_primes.py
@@ -1,3 +1,5 @@
+from loguru import logger
+
 from cpg_flow.targets.sequencing_group import SequencingGroup
 from hailtop.batch import Batch
 from hailtop.batch.job import Job
@@ -44,8 +46,8 @@ def first_n_primes(
 
     job.command(cmd)
 
-    print('-----PRINT PRIMES-----')
-    print(output_file_path)
+    logger.info('-----PRINT PRIMES-----')
+    logger.info(output_file_path)
     b.write_output(job.primes, output_file_path)
 
     return job

--- a/cpg_flow_test/jobs/iterative_digit_sum.py
+++ b/cpg_flow_test/jobs/iterative_digit_sum.py
@@ -1,3 +1,5 @@
+from loguru import logger
+
 from cpg_flow.targets.sequencing_group import SequencingGroup
 from hailtop.batch import Batch
 from hailtop.batch.job import Job
@@ -50,8 +52,8 @@ def iterative_digit_sum(
     """
     job.command(cmd)
 
-    print('-----PRINT ID_SUM-----')
-    print(output_file_path)
+    logger.info('-----PRINT ID_SUM-----')
+    logger.info(output_file_path)
     b.write_output(job.id_sum, output_file_path)
 
     return job

--- a/cpg_flow_test/jobs/iterative_digit_sum.py
+++ b/cpg_flow_test/jobs/iterative_digit_sum.py
@@ -1,8 +1,7 @@
-from loguru import logger
-
 from cpg_flow.targets.sequencing_group import SequencingGroup
 from hailtop.batch import Batch
 from hailtop.batch.job import Job
+from loguru import logger
 
 
 def iterative_digit_sum(

--- a/cpg_flow_test/jobs/say_hi.py
+++ b/cpg_flow_test/jobs/say_hi.py
@@ -1,3 +1,5 @@
+from loguru import logger
+
 from cpg_flow.targets.sequencing_group import SequencingGroup
 from hailtop.batch import Batch
 from hailtop.batch.job import Job
@@ -17,8 +19,8 @@ def say_hi(
 
     job.command(cmd)
 
-    print('-----PRINT SAY HI-----')
-    print(output_file_path)
+    logger.info('-----PRINT SAY HI-----')
+    logger.info(output_file_path)
     b.write_output(job.sayhi, output_file_path)
 
     return job

--- a/cpg_flow_test/jobs/say_hi.py
+++ b/cpg_flow_test/jobs/say_hi.py
@@ -1,8 +1,7 @@
-from loguru import logger
-
 from cpg_flow.targets.sequencing_group import SequencingGroup
 from hailtop.batch import Batch
 from hailtop.batch.job import Job
+from loguru import logger
 
 
 def say_hi(

--- a/cpg_flow_test/stages.py
+++ b/cpg_flow_test/stages.py
@@ -1,5 +1,7 @@
 from typing import Any  # noqa: I001
 
+from loguru import logger
+
 from cpg_flow.stage import CohortStage, MultiCohortStage, SequencingGroupStage, StageInput, StageOutput, stage
 from cpg_flow.targets.cohort import Cohort
 from cpg_flow.targets.multicohort import MultiCohort
@@ -62,8 +64,8 @@ class GeneratePrimes(SequencingGroupStage):
         b = get_batch()
 
         # Print out alignment input for this sequencing group
-        print('-----ALIGNMENT INPUT-----')
-        print(sequencing_group.alignment_input)
+        logger.info('-----ALIGNMENT INPUT-----')
+        logger.info(sequencing_group.alignment_input)
 
         # Write id_sum to output file
         id_sum_output_path = str(self.expected_outputs(sequencing_group).get('id_sum', ''))
@@ -141,8 +143,6 @@ class FilterEvens(CohortStage):
         no_evens_output_path = str(sg_outputs['no_evens'])
         job_no_evens = filter_evens(
             b,
-            inputs,
-            CumulativeCalc,
             cohort.get_sequencing_groups(),
             input_files,
             sg_outputs,
@@ -165,12 +165,12 @@ class BuildAPrimePyramid(MultiCohortStage):
 
     def queue_jobs(self, multicohort: MultiCohort, inputs: StageInput) -> StageOutput | None:
         input_files_filter_evens = inputs.as_dict_by_target(FilterEvens)
-        print('----INPUT FILES FILTER EVENS----')
-        print(input_files_filter_evens)
+        logger.info('----INPUT FILES FILTER EVENS----')
+        logger.info(input_files_filter_evens)
 
         input_files_generate_primes = inputs.as_dict_by_target(GeneratePrimes)
-        print('----INPUT FILES GENERATE PRIMES----')
-        print(input_files_generate_primes)
+        logger.info('----INPUT FILES GENERATE PRIMES----')
+        logger.info(input_files_generate_primes)
 
         input_files: dict[str, dict[str, Any]] = {}
         for cohort in multicohort.get_cohorts():
@@ -180,8 +180,8 @@ class BuildAPrimePyramid(MultiCohortStage):
                 input_files[sg.id]['id_sum'] = input_files_generate_primes[sg.id]['id_sum']
                 input_files[sg.id]['primes'] = input_files_generate_primes[sg.id]['primes']
 
-        print('----INPUT FILES----')
-        print(input_files)
+        logger.info('----INPUT FILES----')
+        logger.info(input_files)
 
         b = get_batch()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,10 @@ readme = "README.md"
 requires-python = ">=3.10,<3.11"
 dependencies = [
     "analysis-runner>=3.2.2",
+    "cpg-flow>=0.2.1",
     "cpg-utils>=5.1.1",
     "hail>=0.2.133",
+    "loguru>=0.7.3",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Paired with https://github.com/populationgenomics/cpg-flow/pull/83/files

Closes #10 

Test runs:

- Driver: https://batch.hail.populationgenomics.org.au/batches/594167
- Worker jobs: https://batch.hail.populationgenomics.org.au/batches/594168

This updates the `print` logging calls to `loguru.logger` calls, to test the changes relevant to SET-339

Also included:

- I've slimmed down the interface to filter_evens. The code in main passes both the exact inputs from the prior stage, and a way of generating them using the StageInput and Stage objects - both inputs are used, but one value overwrites the other. There's some redundancy here, so I've reduced this to the simplest interface (which already existed in code).
- I've included cpg-flow as a project dependency in this repo, without installing it none of the cpg-flow library is legible by and IDE. Potentially moot given this is designed to work in a cpg-flow image, but I think it's still a dependency for this codebase.

### Notes

My IDE had issues parsing through the jobs methods. I think this is because there's some ambiguously named imports:

```
from jobs import build_pyramid, cumulative_calc, filter_evens, first_n_primes, iterative_digit_sum, say_hi
```

and in `jobs.__init__.py`:
```
from jobs.build_pyramid import build_pyramid
from jobs.cumulative_calc import cumulative_calc
from jobs.filter_evens import filter_evens
from jobs.first_n_primes import first_n_primes
from jobs.iterative_digit_sum import iterative_digit_sum
from jobs.say_hi import say_hi
```

So depending on the order of discovery, `build_pyramid` is either `jobs.build_pyramid` or `jobs.build_pyramid.build_pyramid`, one is a module, one is a callable method. My IDE is peppered with `build_pyramid is not Callable` error highlighting, but the code does work...

Not a priority, but it would probably be a good idea to differentiate the job module from the job task to resolve these ambiguities.

