### PR TITLE
Fix project root node for SBOM uploads

### DIFF
--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -18,19 +18,19 @@ jobs:
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  #v8.1.0
 
+      - name: Get project version
+        id: version
+        run: echo "value=$(uv version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+
       - name: Generate SBOM
         run: |
           uv venv
           uv pip install -r requirements.txt
           uvx --from cyclonedx-bom cyclonedx-py environment \
+              --pyproject pyproject.toml \
+              --mc-type application \
               -o sbom.cdx.json \
               .venv/bin/python
-
-      - name: Read project version from pyproject.toml
-        id: project_version
-        run: |
-          VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Authenticate to GCP
         id: auth
@@ -46,12 +46,25 @@ jobs:
         env:
           TOKEN: ${{ steps.auth.outputs.id_token }}
           PROJECT_NAME: ${{ github.event.repository.name }}
-          PROJECT_VERSION: ${{ steps.project_version.outputs.version }}
+          PROJECT_VERSION: ${{ steps.version.outputs.value }}
         run: |
-            curl -sf -X POST "https://dtrack.popgen.rocks/api/v1/bom" \
+            jq -n \
+              --arg name "$PROJECT_NAME" \
+              --arg version "$PROJECT_VERSION" \
+              --arg bom "$(base64 -w0 sbom.cdx.json)" \
+              --arg ref "$GITHUB_REF_NAME" \
+              '{
+                projectName: $name,
+                projectVersion: $version,
+                autoCreate: true,
+                bom: $bom,
+                projectTags: [
+                  {name: "python"},
+                  {name: $ref}
+                ]
+              }' | \
+            curl -sf -X PUT "https://dtrack.popgen.rocks/api/v1/bom" \
               -H "Authorization: Bearer $TOKEN" \
               -H "X-Api-Key: ${{ secrets.DTRACK_API_KEY }}" \
-              -F "projectName=$PROJECT_NAME" \
-              -F "projectVersion=$PROJECT_VERSION" \
-              -F "autoCreate=true" \
-              -F "bom=@sbom.cdx.json"
+              -H "Content-Type: application/json" \
+              -d @-


### PR DESCRIPTION
The project root node is missing for the dependency graph. This attempts to fix that and also simplify the version extraction